### PR TITLE
Fixed CHANGELOG back to semantic 0.0.0 versioning to allow automatic builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixes to bat file password handling
 
-## [0.6.6.0] - 2025-05-05
+## [0.6.6] - 2025-05-07
 
 ### Added
 - Added script for taking subsets of data from given dataset


### PR DESCRIPTION
Our github actions flow will not work with different versioning thanks to [changelog-reader-action](https://github.com/mindsers/changelog-reader-action) enforcing semantic versioning